### PR TITLE
fix #49: S-expression-based textual representation for {Literal,Exp,T…

### DIFF
--- a/driver/Opts.hs
+++ b/driver/Opts.hs
@@ -108,7 +108,7 @@ jsonR =
   eitherReader r
  where
   r =
-    map (T.Scope . map T.reifyAeson) . Aeson.eitherDecode . fromString
+    map (T.Scope . map T.embedAeson) . Aeson.eitherDecode . fromString
 
 currentDirectory :: FilePath
 currentDirectory =

--- a/src/T.hs
+++ b/src/T.hs
@@ -12,7 +12,7 @@ module T
   , parse
   , parseFile
   , render
-  , reifyAeson
+  , embedAeson
 
   , Stdlib
   , stdlib
@@ -28,7 +28,7 @@ import T.Tmpl (Tmpl)
 import T.Parse (parse, parseFile)
 import T.Render (Env, Scope(..), render)
 import T.Stdlib (Stdlib, def)
-import T.Value (Value, reifyAeson)
+import T.Value (Value, embedAeson)
 
 
 stdlib :: Stdlib

--- a/src/T/Exp/Ann.hs
+++ b/src/T/Exp/Ann.hs
@@ -10,7 +10,6 @@ module T.Exp.Ann
   , emptyAnn
   ) where
 
-import Data.Aeson qualified as Aeson
 import Text.Trifecta (DeltaParsing, Span(..), Spanned(..), spanning, spanned)
 
 import T.Prelude
@@ -40,12 +39,6 @@ instance IsString t => IsString (Ann :+ t) where
 instance IsString t => IsString ((Ann, Ann) :+ t) where
   fromString str =
     (emptyAnn, emptyAnn) :+ fromString str
-
-instance Aeson.ToJSON t => Aeson.ToJSON (ann :+ t) where
-  toJSON =
-    Aeson.toJSON . unann
-  toEncoding =
-    Aeson.toEncoding . unann
 
 anning :: DeltaParsing m => m a -> m Ann
 anning =

--- a/src/T/Prelude.hs
+++ b/src/T/Prelude.hs
@@ -44,6 +44,7 @@ module T.Prelude
   , (/)
   , asum
   , bool
+  , concatMap
   , const
   , div
   , either
@@ -127,6 +128,7 @@ import Prelude
   , (-)
   , (*)
   , (/)
+  , concatMap
   , const
   , div
   , either

--- a/src/T/Render.hs
+++ b/src/T/Render.hs
@@ -33,7 +33,7 @@ import T.Stdlib (Stdlib)
 import T.Stdlib qualified as Stdlib
 import T.Value (Value)
 import T.Value qualified as Value
-import T.Tmpl (Tmpl((:*:)))
+import T.Tmpl (Tmpl)
 import T.Tmpl qualified as Tmpl
 
 
@@ -137,9 +137,8 @@ run env0 tmpl =
     Tmpl.Exp exp -> do
       str <- renderExp exp
       build (Builder.fromText str)
-    tmpl0 :*: tmpl1 -> do
-      go tmpl0
-      go tmpl1
+    Tmpl.Cat tmpls ->
+      traverse_ go tmpls
 
 renderExp :: (MonadState Env m, MonadError Error m) => Exp -> m Text
 renderExp exp = do

--- a/src/T/SExp.hs
+++ b/src/T/SExp.hs
@@ -1,0 +1,123 @@
+module T.SExp
+  ( SExp
+  , Paren(..)
+  , var
+  , round
+  , square
+  , curly
+  , To(..)
+  , render
+  ) where
+
+import Data.Text.Encoding qualified as Text
+import Data.Text.Lazy.Builder (Builder)
+import Data.Text.Lazy.Builder qualified as Builder
+import Text.Regex.PCRE.Light.Base qualified as Pcre
+
+import T.Exp.Ann ((:+)(..))
+import T.Name (Name(..))
+import T.Prelude
+
+
+data SExp
+  = App Paren [SExp]
+  | Var Text
+    deriving (Show, Eq)
+
+instance IsString SExp where
+  fromString =
+    Var . fromString
+
+data Paren
+  = Round
+  | Square
+  | Curly
+    deriving (Show, Eq)
+
+var :: Text -> SExp
+var = Var
+
+round :: [SExp] -> SExp
+round =
+  app Round
+
+square :: [SExp] -> SExp
+square =
+  app Square
+
+curly :: [SExp] -> SExp
+curly =
+  app Curly
+
+app :: Paren -> [SExp] -> SExp
+app parenType children =
+  App parenType children
+
+class To a where
+  sexp :: a -> SExp
+
+instance To SExp where
+  sexp x = x
+
+instance To Int64 where
+  sexp =
+    Var . fromString . show
+
+instance To Double where
+  sexp =
+    Var . fromString . show
+
+instance To Text where
+  sexp =
+    Var . fromString . show
+
+instance To Pcre.Regex where
+  sexp (Pcre.Regex _ptr bytes) =
+    sexp (Text.decodeUtf8Lenient bytes)
+
+instance To Name where
+  sexp (Name name) =
+    Var name
+
+instance name ~ Name => To (ann :+ name) where
+  sexp (_ann :+ Name name) =
+    sexp name
+
+render :: SExp -> Builder
+render = \case
+  App parenType children ->
+    fromParenType parenType (sepBy (Builder.singleton ' ') (map render children))
+  Var name ->
+    Builder.fromText name
+ where
+  fromParenType = \case
+    Round -> parens
+    Square -> brackets
+    Curly -> braces
+
+-- this is a sort of `intercalate` for `Builder`s
+sepBy :: Builder -> [Builder] -> Builder
+sepBy sep = go
+ where
+  go [] =
+    mempty
+  go (x0 : []) =
+    x0
+  go (x0 : xs@(_ : _)) =
+    x0 <> sep <> go xs
+
+parens :: Builder -> Builder
+parens =
+  between '(' ')'
+
+brackets :: Builder -> Builder
+brackets =
+  between '[' ']'
+
+braces :: Builder -> Builder
+braces =
+  between '{' '}'
+
+between :: Char -> Char -> Builder -> Builder
+between l r inside =
+  Builder.singleton l <> inside <> Builder.singleton r

--- a/t.cabal
+++ b/t.cabal
@@ -41,6 +41,7 @@ library
       T.Parse.Macro
       T.Prelude
       T.Render
+      T.SExp
       T.Stdlib
       T.Stdlib.Fun
       T.Stdlib.Macro
@@ -114,6 +115,7 @@ test-suite spec
       T.Parse.AnnSpec
       T.ParseSpec
       T.RenderSpec
+      T.SExpSpec
       Paths_t
   hs-source-dirs:
       test

--- a/test/T/RenderSpec.hs
+++ b/test/T/RenderSpec.hs
@@ -24,7 +24,7 @@ import T.Render (Scope(..), render)
 import T.Stdlib (def)
 import T.Stdlib qualified as Stdlib
 import T.Stdlib.Op qualified as Op
-import T.Value (reifyAeson)
+import T.Value (embedAeson)
 
 
 spec :: Spec
@@ -351,7 +351,7 @@ rWith json tmplStr = do
   let
     Aeson.Object o = json
     scope =
-      Scope (map reifyAeson (HashMap.mapKeys Name (Aeson.toHashMapText o)))
+      Scope (map embedAeson (HashMap.mapKeys Name (Aeson.toHashMapText o)))
     stdlib =
       Stdlib.with (def.ops <> opExt) (def.funs <> funExt) (def.macros <> macroExt)
     Right tmpl =

--- a/test/T/SExpSpec.hs
+++ b/test/T/SExpSpec.hs
@@ -1,0 +1,140 @@
+{-# LANGUAGE OverloadedLists #-}
+module T.SExpSpec (spec) where
+
+import Data.Text.Lazy.Builder (Builder)
+import Test.Hspec
+import Text.Regex.PCRE.Light qualified as Pcre
+
+import T.Parse (parse)
+import T.Prelude
+import T.Exp (Exp)
+import T.SExp (render, sexp)
+import T.Stdlib qualified as Stdlib
+import T.Tmpl (Tmpl)
+import T.Tmpl qualified as Tmpl
+import T.Value qualified as Value
+
+
+spec :: Spec
+spec = do
+  context "tmpl" $ do
+    it "raw" $
+      rexp2 "foo" `shouldBe` "(raw \"foo\")"
+
+    it "comment" $
+      rexp2 "{# bar #}" `shouldBe` "(comment \"bar\")"
+
+    it "exp" $
+      rexp2 "{{ 4 }}" `shouldBe` "(exp 4)"
+
+    it "set" $
+      rexp2 "{% set foo = 4 bar = 7 %}" `shouldBe` "(set [[foo 4] [bar 7]])"
+
+    it "let" $
+      rexp2 "{% let foo = 4 bar = 7 %}{{ foo + bar }}{% endlet %}" `shouldBe`
+        "(let [[foo 4] [bar 7]] (exp (+ foo bar)))"
+
+    it "if" $
+      rexp2 "{% if true %}4{% elif false %}7{% endif %}" `shouldBe`
+        "(if [[true (raw \"4\")] [false (raw \"7\")]])"
+
+    it "for" $ do
+      rexp2 "{% for k in [1,2,3] %}4{% endfor %}" `shouldBe`
+        "(for [\"k\" _key] [1 2 3] (raw \"4\") _else)"
+      rexp2 "{% for k, v in [1,2,3] %}4{% else %}7{% endfor %}" `shouldBe`
+        "(for [\"k\" \"v\"] [1 2 3] (raw \"4\") (raw \"7\"))"
+
+    it "cat" $
+      rexp2 "{{ 4 }}foo{{ 7 }}" `shouldBe`
+        "[(exp 4) (raw \"foo\") (exp 7)]"
+
+  context "exp" $ do
+    context "lit" $ do
+      it "null" $
+        rexp "{{ null }}" `shouldBe` "null"
+
+      it "bool" $ do
+        rexp "{{ true }}" `shouldBe` "true"
+        rexp "{{ false }}" `shouldBe` "false"
+
+      it "int" $
+        rexp "{{ 42 }}" `shouldBe` "42"
+
+      it "double" $
+        rexp "{{ 4.2 }}" `shouldBe` "4.2"
+
+      it "string" $
+        rexp "{{ \"foo\" }}" `shouldBe` "\"foo\""
+
+      it "regexp" $
+        rexp "{{ /foo/ }}" `shouldBe` "(regexp \"foo\")"
+
+      it "array" $
+        rexp "{{ [false, 42] }}" `shouldBe` "[false 42]"
+
+      it "object" $
+        rexp "{{ {foo: 42, bar: 4.2} }}" `shouldBe` "{\"bar\" 4.2 \"foo\" 42}"
+
+    it "var" $
+      rexp "{{ foo }}" `shouldBe` "foo"
+
+    it "if" $
+      rexp "{{ if true then 4 else 7 }}" `shouldBe` "(if true 4 7)"
+
+    it "app" $
+      rexp "{{ foo(4, 7) }}" `shouldBe` "(foo 4 7)"
+
+  context "value" $ do
+    it "null" $
+      render (sexp Value.Null) `shouldBe` "null"
+
+    it "bool" $ do
+      render (sexp (Value.Bool False)) `shouldBe` "false"
+      render (sexp (Value.Bool True)) `shouldBe` "true"
+
+    it "int" $
+      render (sexp (Value.Int 42)) `shouldBe` "42"
+
+    it "double" $
+      render (sexp (Value.Double 4.2)) `shouldBe` "4.2"
+
+    it "regexp" $ do
+      let
+        Right regexp =
+          Pcre.compileM "foo" []
+      render (sexp (Value.Regexp regexp)) `shouldBe` "(regexp \"foo\")"
+
+    it "string" $
+      render (sexp (Value.String "foo")) `shouldBe` "\"foo\""
+
+    it "array" $
+      render (sexp (Value.Array [Value.Int 1, Value.Int 2, Value.Int 3])) `shouldBe` "[1 2 3]"
+
+    it "object" $
+      render (sexp (Value.Object [("foo", Value.Int 4), ("bar",  Value.Int 7)])) `shouldBe`
+        "{\"bar\" 7 \"foo\" 4}"
+
+    it "lam" $
+      render (sexp (Value.Lam (\_ -> pure Value.Null))) `shouldBe` "(lambda [_] ...)"
+
+rexp :: ByteString -> Builder
+rexp =
+  render . sexp . pexp
+
+pexp :: ByteString -> Exp
+pexp str = do
+  let
+    Tmpl.Exp exp =
+      texp str
+  exp
+
+rexp2 :: ByteString -> Builder
+rexp2 =
+  render . sexp . texp
+
+texp :: ByteString -> Tmpl
+texp str = do
+  let
+    Right tmpl =
+      parse Stdlib.def str
+  tmpl


### PR DESCRIPTION
…mpl,Value}